### PR TITLE
fix name attribute generation of complex models

### DIFF
--- a/src/ng-fab-form-directive-f.js
+++ b/src/ng-fab-form-directive-f.js
@@ -13,7 +13,7 @@ angular.module('ngFabForm')
                 // no name attr is set already
                 if (attrs.ngModel && !attrs.name) {
                     // set name attribute if none is set
-                    var newNameAttr = attrs.ngModel.replace('.', '_');
+                    var newNameAttr = attrs.ngModel.replace(/\./g, '_');
                     el.attr('name', newNameAttr);
                     attrs.name = newNameAttr;
                 }


### PR DESCRIPTION
When the model has multi levels, the replace was not working. 
Need to switch all . to _, not just the first.

For example: controller.formdata.field was converting to controller_formdata.field and it gave errors. Now it converts to controller_formdata_field.
